### PR TITLE
Issue 003: When deleting storage def, also delete backup info.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -66,6 +66,7 @@ Documentation: https://atbu.readthedocs.io/en/latest/
         "google-auth >= 2.6.5",
         "google-cloud-storage >= 2.3.0",
         "google-resumable-media >= 2.3.2",
-        "tabulate >= 0.8.9"
+        "tabulate >= 0.8.9",
+        "Send2Trash >= 1.8.0",
     ]
 )

--- a/src/atbu/backup/config.py
+++ b/src/atbu/backup/config.py
@@ -16,6 +16,7 @@ r"""ATBU Configuration-related classes/functions.
 """
 import base64
 import fnmatch
+import glob
 import logging
 import os
 from pathlib import Path
@@ -506,6 +507,13 @@ configuration, you can choose to have one created for you.
         g[CONFIG_VALUE_NAME_BACKUP_INFO_DIR] = str(backup_info_dir)
         self.save_config_file()
         return backup_info_dir
+
+    def get_backup_info_file_paths(
+        self,
+        storage_def_name: str,
+    ) -> list[str]:
+        pattern = self.get_backup_info_dir() / f"{storage_def_name}*"
+        return glob.glob(pathname=str(pattern))
 
     def resolve_storage_location(
         self,

--- a/src/atbu/backup/recover.py
+++ b/src/atbu/backup/recover.py
@@ -91,8 +91,9 @@ def handle_restore_backup_info(
     sd = StorageDefinition.storage_def_from_dict(
         storage_def_name=storage_def_name, storage_def_dict=storage_def_dict
     )
-    existing_backup_info_pat = backup_info_dir / f"{storage_def_name}*"
-    existing_backup_info = glob.glob(pathname=str(existing_backup_info_pat))
+    existing_backup_info = atbu_cfg.get_backup_info_file_paths(
+        storage_def_name=storage_def_name
+    )
     if prompt_if_exists and len(existing_backup_info) > 0:
         print(f"Found existing local backup info for {storage_def_name}:")
         for ebi in existing_backup_info:
@@ -169,8 +170,12 @@ listed above. If you are uncertain, you may want to backup those files before pr
     newest_backup_info_wo_stamp = remove_timestamp_from_backupinfo_filename(
         filename=newest_backup_info
     )
-    logging.info(f"Copying {newest_backup_info} to {newest_backup_info_wo_stamp}...")
+    logging.info(f"Copying the most recent backup information...")
+    logging.info(f"  {newest_backup_info}")
+    logging.info(f"...to...")
+    logging.info(f"  {newest_backup_info_wo_stamp}")
     copy2(src=newest_backup_info, dst=newest_backup_info_wo_stamp)
+    logging.info(f"Most recent backup information restored.")
 
 
 def handle_recover(args):

--- a/src/atbu/common/command_line.py
+++ b/src/atbu/common/command_line.py
@@ -125,13 +125,13 @@ def create_argparse():
     #     "--show-secrets", action="store_true", default=False, help=argparse.SUPPRESS
     # )
 
-    #Uncomment to allow --debug-server (for use with VS Code pydebug)
-    parser.add_argument(
-        "--debug-server",
-        help=argparse.SUPPRESS, #"Activate the debug server to listen on specified port, wait for a client connect."
-        type=int,
-        required=False,
-    )
+    # Uncomment to allow --debug-server (for use with VS Code pydebug)
+    # parser.add_argument(
+    #     "--debug-server",
+    #     help=argparse.SUPPRESS, #"Activate the debug server to listen on specified port, wait for a client connect."
+    #     type=int,
+    #     required=False,
+    # )
 
     #
     # Common to all parser
@@ -582,6 +582,16 @@ fail to properly backup your locally stored backup information (which includes t
         action=argparse.BooleanOptionalAction,
         default=False,
         help="Delete without a confirmation prompt.",
+    )
+    cred_delete_storage_def_parser.add_argument(
+        "--delete-backup-info", "--dbi",
+        action=argparse.BooleanOptionalAction,
+        help="""If you specify --no-delete-backup-info (--no-dbi), backup information files
+will not be deleted. By default, a storage definition's backup informatiion
+files are deleted along with the storage definition itself. If this option
+is used without --force, prompting for deleting backup information files
+will be skipped (i.e., user only prompted once re storage defintiion).
+""",
     )
 
     #

--- a/src/atbu/common/util_helpers.py
+++ b/src/atbu/common/util_helpers.py
@@ -18,6 +18,7 @@ from enum import Enum
 from io import SEEK_END, SEEK_SET
 import os
 from pathlib import Path
+import platform
 import random
 from shutil import copy2
 from typing import Union
@@ -34,6 +35,11 @@ class AutoNameEnum(Enum):
 def is_platform_path_case_sensitive():
     return os.path.normcase("A") == "A"
 
+def get_trash_bin_name():
+    if platform.system() == "Windows":
+        return "Recycle Bin"
+    else:
+        return "Trash"
 
 def get_file_max_pos(fd):
     cur_pos = fd.tell()

--- a/tests/test_cloud_providers.py
+++ b/tests/test_cloud_providers.py
@@ -96,13 +96,6 @@ from .common_helpers import (
 TEST_BACKUP_NAME = "atbu-backup-5b497bb3-c9ef-48a9-af7b-2327fc17fb65"
 TEST_CONTAINER_BASE_NAME = "atbu-bucket"
 
-# ENTER ENTER to accept both defaults.
-STDIN_RESP_ENABLE_ENC_PWD_NOT_REQ = f"{os.linesep}{os.linesep}".encode()
-# Enter Y for yes (i.e., confirm storage def deletion)
-STDIN_RESP_ENTER_Y_YES = f"y{os.linesep}".encode()
-STDIN_RESP_ENTER_N_NO = f"n{os.linesep}".encode()
-STDIN_RESP_ENTER_FOR_DEFAULT = f"{os.linesep}".encode()
-
 # import pdb; pdb.set_trace()
 # import pdb; pdb.set_trace()
 
@@ -155,6 +148,9 @@ def create_storage_definition_json(
     if project_id is not None:
         driver_arg += f",project={project_id}"
 
+    # ENTER ENTER to accept both defaults.
+    stdin_resp_enable_enc_pwd_not_req = f"{os.linesep}{os.linesep}".encode()
+
     rr = run_atbu(
         pytester,
         tmp_path,
@@ -165,7 +161,7 @@ def create_storage_definition_json(
         provider,
         f"{TEST_CONTAINER_BASE_NAME}*",
         driver_arg,
-        stdin=STDIN_RESP_ENABLE_ENC_PWD_NOT_REQ,
+        stdin=stdin_resp_enable_enc_pwd_not_req,
         log_base_name="create-storage-def-json",
     )
     assert rr.ret == ExitCode.OK
@@ -222,13 +218,16 @@ def delete_storage_definition_json(
 ):
     delete_container(storage_def_name=TEST_BACKUP_NAME)
 
+    # Enter Y for yes (i.e., confirm storage def deletion)
+    stdin_resp_enter_y_for_yes = f"y{os.linesep}".encode()
+
     rr = run_atbu(
         pytester,
         tmp_path,
         "creds",
         "delete-storage-def",
         TEST_BACKUP_NAME,
-        stdin=STDIN_RESP_ENTER_Y_YES,
+        stdin=stdin_resp_enter_y_for_yes,
         log_base_name="delete-storage-def",
     )
     assert rr.ret == ExitCode.OK


### PR DESCRIPTION
When user deletes a storage definition via 'atbu creds delete-storage-def',
the storage def's backup information remains present out of an abundance
of caution. This may or may not be convenient.

Provider user options to explicitly request deletion of backup information
while also prompting the user if they are not explicit about it.